### PR TITLE
Fix docker-image make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ clean:
 
 .PHONY: docker-image
 docker-image:
-	docker build -f scripts/stretch.docker -t "telegraf:$(COMMIT)" .
+	docker build -f scripts/stretch.docker -t "telegraf:$(commit)" .
 
 plugins/parsers/influx/machine.go: plugins/parsers/influx/machine.go.rl
 	ragel -Z -G2 $^ -o $@


### PR DESCRIPTION
`COMMIT` isn't set anywhere and causes build errors. Use `commit` which is set in `Makefile`