### PR TITLE
Add reflex-test and reflex-build make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,18 @@ clean:
 docker-image:
 	docker build -f scripts/stretch.docker -t "telegraf:$(COMMIT)" .
 
+.PHONY: reflex-docker-build-image
+reflex-docker-build-image:
+	docker build -t telegraf-reflex -f ./scripts/reflex.docker ./scripts
+
+.PHONY: reflex-test
+reflex-test: reflex-docker-build-image
+	@./scripts/reflex.sh test
+
+.PHONY: reflex-build
+reflex-build: reflex-docker-build-image
+	@./scripts/reflex.sh build
+
 plugins/parsers/influx/machine.go: plugins/parsers/influx/machine.go.rl
 	ragel -Z -G2 $^ -o $@
 

--- a/scripts/reflex-build.sh
+++ b/scripts/reflex-build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make telegraf && echo "Build successful!" || echo "Build failed!"

--- a/scripts/reflex-test.sh
+++ b/scripts/reflex-test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test && echo "Tests passed!" || echo "Tests failed!"

--- a/scripts/reflex.docker
+++ b/scripts/reflex.docker
@@ -1,0 +1,5 @@
+FROM golang:1.15
+
+RUN go get github.com/cespare/reflex
+
+WORKDIR /telegraf

--- a/scripts/reflex.sh
+++ b/scripts/reflex.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+CMD=""
+
+case $1 in
+    build)
+        CMD="./scripts/reflex-build.sh"
+        ;;
+
+    test)
+        CMD="./scripts/reflex-test.sh"
+        ;;
+
+    *)
+        echo "Usage: $0 {test|build}"
+        exit 2
+        ;;
+esac
+
+if [[ -z "${GOPATH}" ]] ; then
+    printf "GOPATH unset - sharing of pkg/mod/cache disable dwith docker container\n"
+    docker run --rm -ti \
+        -v $(pwd):/telegraf \
+        --entrypoint reflex \
+        telegraf-reflex:latest -r '(\.go$|go\.mod)' --start-service -- ${CMD}
+else
+    printf "GOPATH set (to %s) - sharing of pkg/mod/cache with docker container enabled\n" "${GOPATH}"
+    docker run --rm -ti \
+        -v $(pwd):/telegraf \
+        -v $GOPATH/pkg/mod/cache:/go/pkg/mod/cache \
+        --entrypoint reflex \
+        telegraf-reflex:latest -r '(\.go$|go\.mod)' --start-service -- ${CMD}
+fi
+
+printf "'%s' finished successfully!\n" "${CMD}"


### PR DESCRIPTION
This PR adds 3 makefile targets:
* `reflex-docker-build-image` - to build the go based docker image with [reflex](https://github.com/cespare/reflex)
* `reflex-build` - to continuously build telegraf (via `make telegraf`) in docker when a `*.go` file or `go.mod` changes anywhere in the repository
* `reflex-test` - to continuously run tests (via `make test`) in docker when a `*.go` file or `go.mod` changes anywhere in the repository