### PR TITLE
Github Actions: automatically create PRs with upstream changes

### DIFF
--- a/.github/workflows/automatic-prs-from-upstream.yml
+++ b/.github/workflows/automatic-prs-from-upstream.yml
@@ -20,5 +20,13 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           title: Upstream changes
-          body: Upstream changes
+          body: |
+            - Upstream changes
+
+            Auto-generated using [create-pull-request][1].
+
+            **Do not edit**: just merge it via [Rebase and merge][2].
+
+            [1]: https://github.com/peter-evans/create-pull-request
+            [2]: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#rebase-and-merge-your-pull-request-commits
           branch: upstream-changes

--- a/.github/workflows/automatic-prs-from-upstream.yml
+++ b/.github/workflows/automatic-prs-from-upstream.yml
@@ -1,0 +1,24 @@
+name: Create PR from upstream
+on:
+  schedule:
+    - cron: '0 * * * *'
+jobs:
+  create-pr-from-upstream:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Reset to upstream's master
+        run: |
+          git remote add upstream https://github.com/influxdata/telegraf.git
+          git fetch upstream master:upstream-master
+          git reset --hard upstream-master
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.PAT }}
+          title: Upstream changes
+          body: Upstream changes
+          branch: upstream-changes


### PR DESCRIPTION
This will set up a Github Action that will use https://github.com/peter-evans/create-pull-request to periodically (as of now set for 1h intervals) create PR with base branch called `upstream-chages` containing all the upstream changes not yet merged to this fork.

If the branch already exists but there are more changes in the upstream it will automatically add the missing commits to this PR.