### PR TITLE
Add make targets for building in docker + docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,14 +162,29 @@ clean:
 docker-image:
 	docker build -f scripts/stretch.docker -t "telegraf:$(commit)" .
 
+## This builds the telegraf binary for the host system's architecture in a docker container.
+## This avoids the need for go toolchain to be installed on the host and produces the binary
+## in repository's root directory.
+.PHONY: telegraf-in-docker
+telegraf-in-docker:
+	@GOOS=$(GOOS) GOARCH=$(GOARCH) ./scripts/telegraf-build-in-docker.sh
+
 .PHONY: reflex-docker-build-image
 reflex-docker-build-image:
 	docker build -t telegraf-reflex -f ./scripts/reflex.docker ./scripts
 
+## This target will repeatedly run tests when any of the .go source files or go.mod files change.
+##
+## The tests themselves are run in a docker container so go toolchain on the host machine
+## is not required.
 .PHONY: reflex-test
 reflex-test: reflex-docker-build-image
 	@./scripts/reflex.sh test
 
+## This target will repeatedly build telegraf when any of the .go source files or go.mod files change.
+##
+## The build itself is run in a docker container so go toolchain on the host machine
+## is not required.
 .PHONY: reflex-build
 reflex-build: reflex-docker-build-image
 	@./scripts/reflex.sh build

--- a/README.md
+++ b/README.md
@@ -65,12 +65,25 @@ Telegraf requires Go version 1.13 or newer, the Makefile requires GNU make.
    make
    ```
 
-### Changelog
+### Using docker for development
+
+If one would like to develop without `go` toolchain installed on the host
+the following `make` targets can be used to ease and speed up the development cycle:
+
+* `make telegraf-in-docker` - this will build telegraf binary in a docker container
+  targeting host's architecture and OS. The resulting binary will be placed in
+  repository's root directory.
+* `make reflex-test` - this will repeatedly run tests in a docker container when any
+  of the .go source files or go.mod files change.
+* `make reflex-build` - this will repeatedly build telegraf in a docker container
+  when any of the .go source files or go.mod files change.
+
+## Changelog
 
 View the [changelog](/CHANGELOG.md) for the latest updates and changes by
 version.
 
-### Nightly Builds
+## Nightly Builds
 
 These builds are generated from the master branch:
 - [telegraf-nightly_darwin_amd64.tar.gz](https://dl.influxdata.com/telegraf/nightlies/telegraf-nightly_darwin_amd64.tar.gz)

--- a/scripts/telegraf-build-in-docker.sh
+++ b/scripts/telegraf-build-in-docker.sh
@@ -2,22 +2,9 @@
 
 set -e
 
-CMD=""
-
-case $1 in
-    build)
-        CMD="./scripts/reflex-build.sh"
-        ;;
-
-    test)
-        CMD="./scripts/reflex-test.sh"
-        ;;
-
-    *)
-        echo "Usage: $0 {test|build}"
-        exit 2
-        ;;
-esac
+GO_IMAGE=golang:1.15
+printf "Building for GOOS=%s and GOARCH=%s\n" "${GOOS}" "${GOARCH}"
+printf "After the build is done you should have 'telegraf' binary built in repository root\n"
 
 if [[ $(which go) ]] ; then
     GOMODCACHE="$(go env GOMODCACHE)"
@@ -30,9 +17,10 @@ if [[ $(which go) ]] ; then
     fi
 fi
 
-docker run --rm -ti \
+docker run --rm -it \
     -v $(pwd):/telegraf \
+    --env GOOS=${GOOS} \
+    --env GOARCH=${GOARCH} \
     ${GOMODCACHE_MOUNT_OPTION} \
     --workdir /telegraf \
-    --entrypoint reflex \
-    telegraf-reflex:latest --decoration=fancy -r '(\.go$|go\.mod)' --start-service -- ${CMD}
+    "${GO_IMAGE}" make telegraf


### PR DESCRIPTION
This adds documentation to existing make targets: reflex-build and reflex-test as well as some documentation around them in comments.

Additionally there is a new target added: telegraf-in-docker which builds telegraf binary in a container, targeting host's architecture and OS and placing it in repository's root directory.

That's a spin off for https://github.com/SumoLogic/telegraf/pull/10