### PR TITLE
Github Actions: change reviewers to team-reviewers and add CODEOWNERS

### DIFF
--- a/.github/workflows/automatic-prs-from-upstream.yml
+++ b/.github/workflows/automatic-prs-from-upstream.yml
@@ -32,7 +32,4 @@ jobs:
 
             [1]: https://github.com/peter-evans/create-pull-request
           branch: upstream-changes
-          reviewers: |
-            pmalek-sumo
-            perk-sumo
-            sumo-drosiek
+          reviewers: pmalek-sumo,perk-sumo,sumo-drosiek

--- a/.github/workflows/automatic-prs-from-upstream.yml
+++ b/.github/workflows/automatic-prs-from-upstream.yml
@@ -32,4 +32,4 @@ jobs:
 
             [1]: https://github.com/peter-evans/create-pull-request
           branch: upstream-changes
-          reviewers: pmalek-sumo,perk-sumo,sumo-drosiek
+          team-reviewers: SumoLogic/opensource-collection-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @SumoLogic/opensource-collection-team


### PR DESCRIPTION
For some reason this doesn't change (not sure if the reason was new line separation - [docs mentions it should work](https://github.com/peter-evans/create-pull-request/#action-inputs))