### PR TITLE
Sumo Logic output plugin: Don't use sampleConfig in tests

### DIFF
--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -383,11 +383,6 @@ func TestTOMLConfig(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name:          "correct sample config",
-			configBytes:   []byte(sampleConfig),
-			expectedError: false,
-		},
-		{
 			name: "carbon2 content type is supported",
 			configBytes: []byte(`
 [[outputs.sumologic]]


### PR DESCRIPTION
It seems we'd need `[[outputs.sumologic]]` to make `sampleConfig` pass the tests and since other plugins don't use it in tests let's also drop this testcase.

Example of broken CircleCI build: https://app.circleci.com/pipelines/github/SumoLogic/telegraf/1/workflows/7d25c7cf-9646-4aea-91b4-fb3b2688fe6f
