### PR TITLE
feat(carbon2parser): don't return an error if one metric fails to parse

### DIFF
--- a/plugins/parsers/carbon2/parser.go
+++ b/plugins/parsers/carbon2/parser.go
@@ -46,7 +46,8 @@ func (p Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 
 		m, err := parseLine(line)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse line: %s, err: %w", line, err)
+			fmt.Printf("E! Failed parsing Carbon2 line with metric: %s\n", line)
+			continue
 		}
 
 		metrics = append(metrics, m)
@@ -145,14 +146,14 @@ func parseBytesForValue(b []byte) (interface{}, error) {
 	if bytes.Contains(trimmed, []byte(".")) {
 		vf, err := strconv.ParseFloat(string(trimmed), 64)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse value: %s, err: %w", b, err)
+			return nil, fmt.Errorf("failed to parse value as float: %s, err: %w", b, err)
 		}
 		return vf, nil
 	}
 
 	vi, err := strconv.ParseInt(string(trimmed), 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse value as int: %s, err: %w", b, err)
 	}
 	return vi, nil
 }

--- a/plugins/parsers/carbon2/parser_test.go
+++ b/plugins/parsers/carbon2/parser_test.go
@@ -217,9 +217,19 @@ _rawName=nite.nite-open-receiver-1.health.jmx.memoryUsage.pools.Compressed-Class
 			},
 		},
 		{
-			name:    "without_metric",
-			input:   []byte("className=HealthTrackerKafkaDataQueueWriter cluster=open-receiver deployment=nite fullClassName=com.sumologic.health.io.HealthTrackerKafkaDataQueueWriter mtype=count node=nite-open-receiver-1 service=open-receiver stat=p75  _primaryMetricType=carbon 0.00 1625855958"),
-			wantErr: true,
+			name:  "without_metric",
+			input: []byte("className=HealthTrackerKafkaDataQueueWriter cluster=open-receiver deployment=nite fullClassName=com.sumologic.health.io.HealthTrackerKafkaDataQueueWriter mtype=count node=nite-open-receiver-1 service=open-receiver stat=p75  _primaryMetricType=carbon 0.00 1625855958"),
+			wantedFunc: func() []telegraf.Metric {
+				return nil
+			},
+		},
+		{
+			name:    "NaN error 1 return ",
+			input:   []byte("className=HealthTrackerKafkaDataQueueWriter cluster=open-receiver deployment=nite fullClassName=com.sumologic.health.io.HealthTrackerKafkaDataQueueWriter metric=kafka.queue.alpha_health_tracker_incidents.offer.timer mtype=count node=nite-open-receiver-1 service=open-receiver stat=p75  _primaryMetricType=carbon NaN 1625855958"),
+			wantErr: false,
+			wantedFunc: func() []telegraf.Metric {
+				return nil
+			},
 		},
 	}
 
@@ -346,8 +356,13 @@ func TestParseLine(t *testing.T) {
 			},
 		},
 		{
-			name:    "without_metric",
+			name:    "metric without metric tag",
 			input:   "className=HealthTrackerKafkaDataQueueWriter cluster=open-receiver deployment=nite fullClassName=com.sumologic.health.io.HealthTrackerKafkaDataQueueWriter mtype=count node=nite-open-receiver-1 service=open-receiver stat=p75  _primaryMetricType=carbon 0.00 1625855958",
+			wantErr: true,
+		},
+		{
+			name:    "NaN error 1 return ",
+			input:   "className=HealthTrackerKafkaDataQueueWriter cluster=open-receiver deployment=nite fullClassName=com.sumologic.health.io.HealthTrackerKafkaDataQueueWriter metric=kafka.queue.alpha_health_tracker_incidents.offer.timer mtype=count node=nite-open-receiver-1 service=open-receiver stat=p75  _primaryMetricType=carbon NaN 1625855958",
 			wantErr: true,
 		},
 	}
@@ -357,17 +372,24 @@ func TestParseLine(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			m, err := p.ParseLine(tc.input)
 			if tc.wantErr {
-				assert.Error(t, err)
-				return
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
-			require.NoError(t, err)
-
-			expected := tc.wantedFunc()
-			assert.Equalf(t, expected.Name(), m.Name(), "Metric name not as expected")
-			assert.Equal(t, expected.Fields(), m.Fields())
-			assert.Equal(t, expected.Tags(), m.Tags())
-			assert.Equal(t, expected.Time(), m.Time())
+			if tc.wantedFunc != nil {
+				expected := tc.wantedFunc()
+				if expected == nil {
+					assert.Nil(t, m)
+					return
+				}
+				assert.Equalf(t, expected.Name(), m.Name(), "Metric name not as expected")
+				assert.Equal(t, expected.Fields(), m.Fields())
+				assert.Equal(t, expected.Tags(), m.Tags())
+				assert.Equal(t, expected.Time(), m.Time())
+			} else {
+				assert.Nil(t, m)
+			}
 		})
 	}
 }


### PR DESCRIPTION
When parsing a single line then return an error if the line doesn't parse properly but when parsing multiple lines do not report an error if one of them fails, just continue parsing other lines.