### PR TITLE
fix(http_listener_v2): shutdown without channel panics

### DIFF
--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -2,6 +2,7 @@ package http_listener_v2
 
 import (
 	"compress/gzip"
+	"context"
 	"crypto/subtle"
 	"crypto/tls"
 	"errors"
@@ -38,19 +39,20 @@ type TimeFunc func() time.Time
 
 // HTTPListenerV2 is an input plugin that collects external metrics sent via HTTP
 type HTTPListenerV2 struct {
-	ServiceAddress string            `toml:"service_address"`
-	Path           string            `toml:"path"`
-	Paths          []string          `toml:"paths"`
-	PathTag        bool              `toml:"path_tag"`
-	Methods        []string          `toml:"methods"`
-	DataSource     string            `toml:"data_source"`
-	ReadTimeout    config.Duration   `toml:"read_timeout"`
-	WriteTimeout   config.Duration   `toml:"write_timeout"`
-	MaxBodySize    config.Size       `toml:"max_body_size"`
-	Port           int               `toml:"port"`
-	BasicUsername  string            `toml:"basic_username"`
-	BasicPassword  string            `toml:"basic_password"`
-	HTTPHeaderTags map[string]string `toml:"http_header_tags"`
+	ServiceAddress  string            `toml:"service_address"`
+	Path            string            `toml:"path"`
+	Paths           []string          `toml:"paths"`
+	PathTag         bool              `toml:"path_tag"`
+	Methods         []string          `toml:"methods"`
+	DataSource      string            `toml:"data_source"`
+	ReadTimeout     config.Duration   `toml:"read_timeout"`
+	WriteTimeout    config.Duration   `toml:"write_timeout"`
+	ShutdownTimeout config.Duration   `toml:"shutdown_timeout"`
+	MaxBodySize     config.Size       `toml:"max_body_size"`
+	Port            int               `toml:"port"`
+	BasicUsername   string            `toml:"basic_username"`
+	BasicPassword   string            `toml:"basic_password"`
+	HTTPHeaderTags  map[string]string `toml:"http_header_tags"`
 
 	tlsint.ServerConfig
 	tlsConf *tls.Config
@@ -58,10 +60,11 @@ type HTTPListenerV2 struct {
 	TimeFunc
 	Log telegraf.Logger
 
-	wg    sync.WaitGroup
-	close chan struct{}
+	wg      sync.WaitGroup
+	metrics chan []telegraf.Metric
 
 	listener net.Listener
+	server   *http.Server
 
 	parsers.Parser
 	acc telegraf.Accumulator
@@ -88,6 +91,8 @@ const sampleConfig = `
   # read_timeout = "10s"
   ## maximum duration before timing out write of the response
   # write_timeout = "10s"
+  ## maximum duration before forcefully closing the HTTP server when shutting it down
+  # shutdown_timeout = "15s"
 
   ## Maximum allowed http request body size in bytes.
   ## 0 means to use the default of 524,288,000 bytes (500 mebibytes)
@@ -150,6 +155,9 @@ func (h *HTTPListenerV2) Start(acc telegraf.Accumulator) error {
 	if h.WriteTimeout < config.Duration(time.Second) {
 		h.WriteTimeout = config.Duration(time.Second * 10)
 	}
+	if h.ShutdownTimeout < config.Duration(time.Second) {
+		h.ShutdownTimeout = config.Duration(time.Second * 15)
+	}
 
 	// Append h.Path to h.Paths
 	if h.Path != "" && !choice.Contains(h.Path, h.Paths) {
@@ -158,16 +166,37 @@ func (h *HTTPListenerV2) Start(acc telegraf.Accumulator) error {
 
 	h.acc = acc
 
-	server := h.createHTTPServer()
+	h.server = h.createHTTPServer()
+
+	// This goroutine just moves data from the metrics channel to the accumulator
+	// It exists so we can select on writing to the metrics channel and handle cancellation correctly
+	// in the request handler.
+	go func() {
+		// Handle the case where the accumulator channel is closed while shutting down. We do this to
+		// avoid changing the accumulator API to allow for more graceful handling of this channel.
+		defer func() {
+			if err := recover(); err != nil {
+				h.Log.Error(err)
+			}
+		}()
+		for {
+			metrics, ok := <-h.metrics
+			if !ok {
+				return
+			}
+			for _, m := range metrics {
+				h.acc.AddMetric(m)
+			}
+		}
+	}()
 
 	h.wg.Add(1)
 	go func() {
 		defer h.wg.Done()
-		if err := server.Serve(h.listener); err != nil {
+		if err := h.server.Serve(h.listener); err != nil {
 			if !errors.Is(err, net.ErrClosed) {
 				h.Log.Errorf("Serve failed: %v", err)
 			}
-			close(h.close)
 		}
 	}()
 
@@ -188,11 +217,14 @@ func (h *HTTPListenerV2) createHTTPServer() *http.Server {
 
 // Stop cleans up all resources
 func (h *HTTPListenerV2) Stop() {
-	if h.listener != nil {
-		// Ignore the returned error as we cannot do anything about it anyway
-		//nolint:errcheck,revive
-		h.listener.Close()
+	if h.server != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(h.ShutdownTimeout))
+		defer cancel()
+		if err := h.server.Shutdown(ctx); err != nil {
+			h.Log.Errorf("server shutdown error: %v", err)
+		}
 	}
+	close(h.metrics)
 	h.wg.Wait()
 }
 
@@ -229,13 +261,6 @@ func (h *HTTPListenerV2) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 }
 
 func (h *HTTPListenerV2) serveWrite(res http.ResponseWriter, req *http.Request) {
-	select {
-	case <-h.close:
-		res.WriteHeader(http.StatusGone)
-		return
-	default:
-	}
-
 	// Check that the content length is not too large for us to handle.
 	if req.ContentLength > int64(h.MaxBodySize) {
 		if err := tooLarge(res); err != nil {
@@ -293,11 +318,12 @@ func (h *HTTPListenerV2) serveWrite(res http.ResponseWriter, req *http.Request) 
 		if h.PathTag {
 			m.AddTag(pathTag, req.URL.Path)
 		}
-
-		h.acc.AddMetric(m)
 	}
-
-	res.WriteHeader(http.StatusNoContent)
+	select {
+	case <-req.Context().Done():
+	case h.metrics <- metrics:
+		res.WriteHeader(http.StatusNoContent)
+	}
 }
 
 func (h *HTTPListenerV2) collectBody(res http.ResponseWriter, req *http.Request) ([]byte, bool) {
@@ -416,7 +442,7 @@ func init() {
 			Paths:          []string{"/telegraf"},
 			Methods:        []string{"POST", "PUT"},
 			DataSource:     body,
-			close:          make(chan struct{}),
+			metrics:        make(chan []telegraf.Metric),
 		}
 	})
 }

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -16,7 +16,10 @@ import (
 	"github.com/golang/snappy"
 	"github.com/stretchr/testify/require"
 
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/agent"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -56,7 +59,7 @@ func newTestHTTPListenerV2() *HTTPListenerV2 {
 		TimeFunc:       time.Now,
 		MaxBodySize:    config.Size(70000),
 		DataSource:     "body",
-		close:          make(chan struct{}),
+		metrics:        make(chan []telegraf.Metric),
 	}
 	return listener
 }
@@ -79,7 +82,7 @@ func newTestHTTPSListenerV2() *HTTPListenerV2 {
 		Parser:         parser,
 		ServerConfig:   *pki.TLSServerConfig(),
 		TimeFunc:       time.Now,
-		close:          make(chan struct{}),
+		metrics:        make(chan []telegraf.Metric),
 	}
 
 	return listener
@@ -107,6 +110,25 @@ func createURL(listener *HTTPListenerV2, scheme string, path string, rawquery st
 	return u.String()
 }
 
+type TestMetricMaker struct {
+}
+
+func (tm *TestMetricMaker) Name() string {
+	return "TestPlugin"
+}
+
+func (tm *TestMetricMaker) LogName() string {
+	return tm.Name()
+}
+
+func (tm *TestMetricMaker) MakeMetric(metric telegraf.Metric) telegraf.Metric {
+	return metric
+}
+
+func (tm *TestMetricMaker) Log() telegraf.Logger {
+	return models.NewLogger("TestPlugin", "test", "")
+}
+
 func TestInvalidListenerConfig(t *testing.T) {
 	parser, _ := parsers.NewInfluxParser()
 
@@ -119,7 +141,7 @@ func TestInvalidListenerConfig(t *testing.T) {
 		TimeFunc:       time.Now,
 		MaxBodySize:    config.Size(70000),
 		DataSource:     "body",
-		close:          make(chan struct{}),
+		metrics:        make(chan []telegraf.Metric),
 	}
 
 	require.Error(t, listener.Init())
@@ -328,7 +350,7 @@ func TestWriteHTTPExactMaxBodySize(t *testing.T) {
 		Parser:         parser,
 		MaxBodySize:    config.Size(len(hugeMetric)),
 		TimeFunc:       time.Now,
-		close:          make(chan struct{}),
+		metrics:        make(chan []telegraf.Metric),
 	}
 
 	acc := &testutil.Accumulator{}
@@ -353,7 +375,7 @@ func TestWriteHTTPVerySmallMaxBody(t *testing.T) {
 		Parser:         parser,
 		MaxBodySize:    config.Size(4096),
 		TimeFunc:       time.Now,
-		close:          make(chan struct{}),
+		metrics:        make(chan []telegraf.Metric),
 	}
 
 	acc := &testutil.Accumulator{}
@@ -475,6 +497,69 @@ func TestWriteHTTPHighTraffic(t *testing.T) {
 
 	acc.Wait(25000)
 	require.Equal(t, int64(25000), int64(acc.NMetrics()))
+}
+
+func TestShutdown(t *testing.T) {
+	listener := newTestHTTPListenerV2()
+
+	// use a real accumulator with a channel, we want to check how shutdown behaves in respect to it
+	metrics := make(chan telegraf.Metric)
+	acc := agent.NewAccumulator(&TestMetricMaker{}, metrics)
+
+	require.NoError(t, listener.Init())
+	require.NoError(t, listener.Start(acc))
+
+	// make a request with some data
+	resp, err := http.Post(createURL(listener, "http", "/write", "db=mydb"), "", bytes.NewBuffer([]byte(testMsgNoNewline)))
+	if err != nil {
+		return
+	}
+	if err := resp.Body.Close(); err != nil {
+		return
+	}
+	if resp.StatusCode != 204 {
+		return
+	}
+
+	// stop the plugin and see if it gracefully handles the accumulator channel being closed
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		listener.Stop()
+	}()
+	<-metrics
+	wg.Wait()
+	close(metrics)
+}
+
+func TestShutdownTimeout(t *testing.T) {
+	listener := newTestHTTPListenerV2()
+	listener.ShutdownTimeout = config.Duration(time.Second)
+
+	// use a real accumulator with a channel, we want to check how shutdown behaves in respect to it
+	metrics := make(chan telegraf.Metric)
+	acc := agent.NewAccumulator(&TestMetricMaker{}, metrics)
+
+	require.NoError(t, listener.Init())
+	require.NoError(t, listener.Start(acc))
+
+	// make a request with some data
+	resp, err := http.Post(createURL(listener, "http", "/write", "db=mydb"), "", bytes.NewBuffer([]byte(testMsgNoNewline)))
+	if err != nil {
+		return
+	}
+	if err := resp.Body.Close(); err != nil {
+		return
+	}
+	if resp.StatusCode != 204 {
+		return
+	}
+
+	// stop the plugin and see if it exits even with a handler still blocked on writing to the accumulator
+
+	listener.Stop()
+	close(metrics)
 }
 
 func TestReceive404ForInvalidEndpoint(t *testing.T) {


### PR DESCRIPTION
If the accumulator channel is closed before we shut down, we get a panic. To avoid this, use an intermediary channel and wait on request context cancellation there. Also use `server.Shutdown` for shutting down instead of closing the socket directly.