### PR TITLE
feat(http_listener_v2): add request handler timeouts

### DIFF
--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -39,20 +39,21 @@ type TimeFunc func() time.Time
 
 // HTTPListenerV2 is an input plugin that collects external metrics sent via HTTP
 type HTTPListenerV2 struct {
-	ServiceAddress  string            `toml:"service_address"`
-	Path            string            `toml:"path" deprecated:"1.20.0;use 'paths' instead"`
-	Paths           []string          `toml:"paths"`
-	PathTag         bool              `toml:"path_tag"`
-	Methods         []string          `toml:"methods"`
-	DataSource      string            `toml:"data_source"`
-	ReadTimeout     config.Duration   `toml:"read_timeout"`
-	WriteTimeout    config.Duration   `toml:"write_timeout"`
-	ShutdownTimeout config.Duration   `toml:"shutdown_timeout"`
-	MaxBodySize     config.Size       `toml:"max_body_size"`
-	Port            int               `toml:"port"`
-	BasicUsername   string            `toml:"basic_username"`
-	BasicPassword   string            `toml:"basic_password"`
-	HTTPHeaderTags  map[string]string `toml:"http_header_tags"`
+	ServiceAddress        string            `toml:"service_address"`
+	Path                  string            `toml:"path"`
+	Paths                 []string          `toml:"paths"`
+	PathTag               bool              `toml:"path_tag"`
+	Methods               []string          `toml:"methods"`
+	DataSource            string            `toml:"data_source"`
+	ReadTimeout           config.Duration   `toml:"read_timeout"`
+	WriteTimeout          config.Duration   `toml:"write_timeout"`
+	ShutdownTimeout       config.Duration   `toml:"shutdown_timeout"`
+	RequestHandlerTimeout config.Duration   `toml:"request_handler_timeout"`
+	MaxBodySize           config.Size       `toml:"max_body_size"`
+	Port                  int               `toml:"port"`
+	BasicUsername         string            `toml:"basic_username"`
+	BasicPassword         string            `toml:"basic_password"`
+	HTTPHeaderTags        map[string]string `toml:"http_header_tags"`
 
 	tlsint.ServerConfig
 	tlsConf *tls.Config
@@ -89,6 +90,12 @@ const sampleConfig = `
   # write_timeout = "10s"
   ## maximum duration before forcefully closing the HTTP server when shutting it down
   # shutdown_timeout = "15s"
+  ## maximum duration to wait for the request handler to return before returning 503 instead
+  ## In resource-constrained situations, this can be used to trade off memory consumption
+  ## against CPU efficiency. A higher timeout means we use more memory on accepted requests
+  ## but waste fewer CPU cycles on validation and processing of requests we'll return a 503
+  ## for anyway
+  # request_handler_timeout = "5s"
 
   ## Maximum allowed http request body size in bytes.
   ## 0 means to use the default of 524,288,000 bytes (500 mebibytes)
@@ -154,6 +161,9 @@ func (h *HTTPListenerV2) Start(acc telegraf.Accumulator) error {
 	if h.ShutdownTimeout < config.Duration(time.Second) {
 		h.ShutdownTimeout = config.Duration(time.Second * 15)
 	}
+	if h.RequestHandlerTimeout < config.Duration(time.Second) {
+		h.RequestHandlerTimeout = config.Duration(time.Second * 5)
+	}
 
 	// Append h.Path to h.Paths
 	if h.Path != "" && !choice.Contains(h.Path, h.Paths) {
@@ -204,7 +214,7 @@ func (h *HTTPListenerV2) Start(acc telegraf.Accumulator) error {
 func (h *HTTPListenerV2) createHTTPServer() *http.Server {
 	return &http.Server{
 		Addr:         h.ServiceAddress,
-		Handler:      h,
+		Handler:      http.TimeoutHandler(h, time.Duration(h.RequestHandlerTimeout), "service temporarily unavailable"),
 		ReadTimeout:  time.Duration(h.ReadTimeout),
 		WriteTimeout: time.Duration(h.WriteTimeout),
 		TLSConfig:    h.tlsConf,


### PR DESCRIPTION
Add request handler timeouts as a basic form of backpressure. If the request handler doesn't return in the specified time, a 503 is returned, and the context is cancelled. This is done via net/http's normal handler timeout mechanism.
