### PR TITLE
feat: restore socket_listener plugin

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -73,6 +73,7 @@ import (
 
 	_ "github.com/influxdata/telegraf/plugins/inputs/snmp"
 	_ "github.com/influxdata/telegraf/plugins/inputs/snmp_trap"
+	_ "github.com/influxdata/telegraf/plugins/inputs/socket_listener"
 	_ "github.com/influxdata/telegraf/plugins/inputs/sqlserver"
 	_ "github.com/influxdata/telegraf/plugins/inputs/system"
 	_ "github.com/influxdata/telegraf/plugins/inputs/varnish"

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -1,0 +1,142 @@
+# Socket Listener Input Plugin
+
+The Socket Listener is a service input plugin that listens for messages from
+streaming (tcp, unix) or datagram (udp, unixgram) protocols.
+
+The plugin expects messages in the
+[Telegraf Input Data Formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md).
+
+## Configuration
+
+This is a sample configuration for the plugin.
+
+```toml
+# Generic socket listener capable of handling multiple socket types.
+[[inputs.socket_listener]]
+  ## URL to listen on
+  # service_address = "tcp://:8094"
+  # service_address = "tcp://127.0.0.1:http"
+  # service_address = "tcp4://:8094"
+  # service_address = "tcp6://:8094"
+  # service_address = "tcp6://[2001:db8::1]:8094"
+  # service_address = "udp://:8094"
+  # service_address = "udp4://:8094"
+  # service_address = "udp6://:8094"
+  # service_address = "unix:///tmp/telegraf.sock"
+  # service_address = "unixgram:///tmp/telegraf.sock"
+
+  ## Change the file mode bits on unix sockets.  These permissions may not be
+  ## respected by some platforms, to safely restrict write permissions it is best
+  ## to place the socket into a directory that has previously been created
+  ## with the desired permissions.
+  ##   ex: socket_mode = "777"
+  # socket_mode = ""
+
+  ## Maximum number of concurrent connections.
+  ## Only applies to stream sockets (e.g. TCP).
+  ## 0 (default) is unlimited.
+  # max_connections = 1024
+
+  ## Read timeout.
+  ## Only applies to stream sockets (e.g. TCP).
+  ## 0 (default) is unlimited.
+  # read_timeout = "30s"
+
+  ## Optional TLS configuration.
+  ## Only applies to stream sockets (e.g. TCP).
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key  = "/etc/telegraf/key.pem"
+  ## Enables client authentication if set.
+  # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Maximum socket buffer size (in bytes when no unit specified).
+  ## For stream sockets, once the buffer fills up, the sender will start backing up.
+  ## For datagram sockets, once the buffer fills up, metrics will start dropping.
+  ## Defaults to the OS default.
+  # read_buffer_size = "64KiB"
+
+  ## Period between keep alive probes.
+  ## Only applies to TCP sockets.
+  ## 0 disables keep alive probes.
+  ## Defaults to the OS configuration.
+  # keep_alive_period = "5m"
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  # data_format = "influx"
+
+  ## Content encoding for message payloads, can be set to "gzip" to or
+  ## "identity" to apply no encoding.
+  # content_encoding = "identity"
+```
+
+## A Note on UDP OS Buffer Sizes
+
+The `read_buffer_size` config option can be used to adjust the size of the socket
+buffer, but this number is limited by OS settings. On Linux, `read_buffer_size`
+will default to `rmem_default` and will be capped by `rmem_max`. On BSD systems,
+`read_buffer_size` is capped by `maxsockbuf`, and there is no OS default
+setting.
+
+Instructions on how to adjust these OS settings are available below.
+
+Some OSes (most notably, Linux) place very restrictive limits on the performance
+of UDP protocols. It is _highly_ recommended that you increase these OS limits to
+at least 8MB before trying to run large amounts of UDP traffic to your instance.
+8MB is just a recommendation, and can be adjusted higher.
+
+### Linux
+
+Check the current UDP/IP receive buffer limit & default by typing the following
+commands:
+
+```sh
+sysctl net.core.rmem_max
+sysctl net.core.rmem_default
+```
+
+If the values are less than 8388608 bytes you should add the following lines to
+the /etc/sysctl.conf file:
+
+```text
+net.core.rmem_max=8388608
+net.core.rmem_default=8388608
+```
+
+Changes to /etc/sysctl.conf do not take effect until reboot.
+To update the values immediately, type the following commands as root:
+
+```sh
+sysctl -w net.core.rmem_max=8388608
+sysctl -w net.core.rmem_default=8388608
+```
+
+### BSD/Darwin
+
+On BSD/Darwin systems you need to add about a 15% padding to the kernel limit
+socket buffer. Meaning if you want an 8MB buffer (8388608 bytes) you need to set
+the kernel limit to `8388608*1.15 = 9646900`. This is not documented anywhere but
+happens
+[in the kernel here.](https://github.com/freebsd/freebsd/blob/master/sys/kern/uipc_sockbuf.c#L63-L64)
+
+Check the current UDP/IP buffer limit by typing the following command:
+
+```sh
+sysctl kern.ipc.maxsockbuf
+```
+
+If the value is less than 9646900 bytes you should add the following lines
+to the /etc/sysctl.conf file (create it if necessary):
+
+```text
+kern.ipc.maxsockbuf=9646900
+```
+
+Changes to /etc/sysctl.conf do not take effect until reboot.
+To update the values immediately, type the following command as root:
+
+```sh
+sysctl -w kern.ipc.maxsockbuf=9646900
+```

--- a/plugins/inputs/socket_listener/socket_listener.go
+++ b/plugins/inputs/socket_listener/socket_listener.go
@@ -1,0 +1,470 @@
+package socket_listener
+
+import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
+	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/parsers"
+)
+
+type setReadBufferer interface {
+	SetReadBuffer(bytes int) error
+}
+
+type streamSocketListener struct {
+	net.Listener
+	*SocketListener
+
+	sockType string
+
+	connections    map[string]net.Conn
+	connectionsMtx sync.Mutex
+}
+
+func (ssl *streamSocketListener) listen() {
+	ssl.connections = map[string]net.Conn{}
+
+	wg := sync.WaitGroup{}
+
+	for {
+		c, err := ssl.Accept()
+		if err != nil {
+			if !strings.HasSuffix(err.Error(), ": use of closed network connection") {
+				ssl.Log.Error(err.Error())
+			}
+			break
+		}
+
+		if ssl.ReadBufferSize > 0 {
+			if srb, ok := c.(setReadBufferer); ok {
+				if err := srb.SetReadBuffer(int(ssl.ReadBufferSize)); err != nil {
+					ssl.Log.Error(err.Error())
+					break
+				}
+			} else {
+				ssl.Log.Warnf("Unable to set read buffer on a %s socket", ssl.sockType)
+			}
+		}
+
+		ssl.connectionsMtx.Lock()
+		if ssl.MaxConnections > 0 && len(ssl.connections) >= ssl.MaxConnections {
+			ssl.connectionsMtx.Unlock()
+			// Ignore the returned error as we cannot do anything about it anyway
+			//nolint:errcheck,revive
+			c.Close()
+			continue
+		}
+		ssl.connections[c.RemoteAddr().String()] = c
+		ssl.connectionsMtx.Unlock()
+
+		if err := ssl.setKeepAlive(c); err != nil {
+			ssl.Log.Errorf("Unable to configure keep alive %q: %s", ssl.ServiceAddress, err.Error())
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ssl.read(c)
+		}()
+	}
+
+	ssl.connectionsMtx.Lock()
+	for _, c := range ssl.connections {
+		// Ignore the returned error as we cannot do anything about it anyway
+		//nolint:errcheck,revive
+		c.Close()
+	}
+	ssl.connectionsMtx.Unlock()
+
+	wg.Wait()
+}
+
+func (ssl *streamSocketListener) setKeepAlive(c net.Conn) error {
+	if ssl.KeepAlivePeriod == nil {
+		return nil
+	}
+	tcpc, ok := c.(*net.TCPConn)
+	if !ok {
+		return fmt.Errorf("cannot set keep alive on a %s socket", strings.SplitN(ssl.ServiceAddress, "://", 2)[0])
+	}
+	if *ssl.KeepAlivePeriod == 0 {
+		return tcpc.SetKeepAlive(false)
+	}
+	if err := tcpc.SetKeepAlive(true); err != nil {
+		return err
+	}
+	return tcpc.SetKeepAlivePeriod(time.Duration(*ssl.KeepAlivePeriod))
+}
+
+func (ssl *streamSocketListener) removeConnection(c net.Conn) {
+	ssl.connectionsMtx.Lock()
+	delete(ssl.connections, c.RemoteAddr().String())
+	ssl.connectionsMtx.Unlock()
+}
+
+func (ssl *streamSocketListener) read(c net.Conn) {
+	defer ssl.removeConnection(c)
+	defer c.Close()
+
+	decoder, err := internal.NewStreamContentDecoder(ssl.ContentEncoding, c)
+	if err != nil {
+		ssl.Log.Error("Read error: %v", err)
+		return
+	}
+
+	scnr := bufio.NewScanner(decoder)
+	for {
+		if ssl.ReadTimeout != nil && *ssl.ReadTimeout > 0 {
+			if err := c.SetReadDeadline(time.Now().Add(time.Duration(*ssl.ReadTimeout))); err != nil {
+				ssl.Log.Error("setting read deadline failed: %v", err)
+				return
+			}
+		}
+		if !scnr.Scan() {
+			break
+		}
+
+		body := scnr.Bytes()
+
+		metrics, err := ssl.Parse(body)
+		if err != nil {
+			ssl.Log.Errorf("Unable to parse incoming line: %s", err.Error())
+			// TODO rate limit
+			continue
+		}
+		for _, m := range metrics {
+			ssl.AddMetric(m)
+		}
+	}
+
+	if err := scnr.Err(); err != nil {
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			ssl.Log.Debugf("Timeout in plugin: %s", err.Error())
+		} else if netErr != nil && !strings.HasSuffix(err.Error(), ": use of closed network connection") {
+			ssl.Log.Error(err.Error())
+		}
+	}
+}
+
+type packetSocketListener struct {
+	net.PacketConn
+	*SocketListener
+	decoder internal.ContentDecoder
+}
+
+func (psl *packetSocketListener) listen() {
+	buf := make([]byte, 64*1024) // 64kb - maximum size of IP packet
+	for {
+		n, _, err := psl.ReadFrom(buf)
+		if err != nil {
+			if !strings.HasSuffix(err.Error(), ": use of closed network connection") {
+				psl.Log.Error(err.Error())
+			}
+			break
+		}
+
+		body, err := psl.decoder.Decode(buf[:n])
+		if err != nil {
+			psl.Log.Errorf("Unable to decode incoming packet: %s", err.Error())
+		}
+
+		metrics, err := psl.Parse(body)
+		if err != nil {
+			psl.Log.Errorf("Unable to parse incoming packet: %s", err.Error())
+			// TODO rate limit
+			continue
+		}
+		for _, m := range metrics {
+			psl.AddMetric(m)
+		}
+	}
+}
+
+type SocketListener struct {
+	ServiceAddress  string           `toml:"service_address"`
+	MaxConnections  int              `toml:"max_connections"`
+	ReadBufferSize  config.Size      `toml:"read_buffer_size"`
+	ReadTimeout     *config.Duration `toml:"read_timeout"`
+	KeepAlivePeriod *config.Duration `toml:"keep_alive_period"`
+	SocketMode      string           `toml:"socket_mode"`
+	ContentEncoding string           `toml:"content_encoding"`
+	tlsint.ServerConfig
+
+	wg sync.WaitGroup
+
+	Log telegraf.Logger
+
+	parsers.Parser
+	telegraf.Accumulator
+	io.Closer
+}
+
+func (sl *SocketListener) Description() string {
+	return "Generic socket listener capable of handling multiple socket types."
+}
+
+func (sl *SocketListener) SampleConfig() string {
+	return `
+  ## URL to listen on
+  # service_address = "tcp://:8094"
+  # service_address = "tcp://127.0.0.1:http"
+  # service_address = "tcp4://:8094"
+  # service_address = "tcp6://:8094"
+  # service_address = "tcp6://[2001:db8::1]:8094"
+  # service_address = "udp://:8094"
+  # service_address = "udp4://:8094"
+  # service_address = "udp6://:8094"
+  # service_address = "unix:///tmp/telegraf.sock"
+  # service_address = "unixgram:///tmp/telegraf.sock"
+
+  ## Change the file mode bits on unix sockets.  These permissions may not be
+  ## respected by some platforms, to safely restrict write permissions it is best
+  ## to place the socket into a directory that has previously been created
+  ## with the desired permissions.
+  ##   ex: socket_mode = "777"
+  # socket_mode = ""
+
+  ## Maximum number of concurrent connections.
+  ## Only applies to stream sockets (e.g. TCP).
+  ## 0 (default) is unlimited.
+  # max_connections = 1024
+
+  ## Read timeout.
+  ## Only applies to stream sockets (e.g. TCP).
+  ## 0 (default) is unlimited.
+  # read_timeout = "30s"
+
+  ## Optional TLS configuration.
+  ## Only applies to stream sockets (e.g. TCP).
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key  = "/etc/telegraf/key.pem"
+  ## Enables client authentication if set.
+  # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Maximum socket buffer size (in bytes when no unit specified).
+  ## For stream sockets, once the buffer fills up, the sender will start backing up.
+  ## For datagram sockets, once the buffer fills up, metrics will start dropping.
+  ## Defaults to the OS default.
+  # read_buffer_size = "64KiB"
+
+  ## Period between keep alive probes.
+  ## Only applies to TCP sockets.
+  ## 0 disables keep alive probes.
+  ## Defaults to the OS configuration.
+  # keep_alive_period = "5m"
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  # data_format = "influx"
+
+  ## Content encoding for message payloads, can be set to "gzip" to or
+  ## "identity" to apply no encoding.
+  # content_encoding = "identity"
+`
+}
+
+func (sl *SocketListener) Gather(_ telegraf.Accumulator) error {
+	return nil
+}
+
+func (sl *SocketListener) SetParser(parser parsers.Parser) {
+	sl.Parser = parser
+}
+
+func (sl *SocketListener) Start(acc telegraf.Accumulator) error {
+	sl.Accumulator = acc
+	spl := strings.SplitN(sl.ServiceAddress, "://", 2)
+	if len(spl) != 2 {
+		return fmt.Errorf("invalid service address: %s", sl.ServiceAddress)
+	}
+
+	protocol := spl[0]
+	addr := spl[1]
+
+	if protocol == "unix" || protocol == "unixpacket" || protocol == "unixgram" {
+		// no good way of testing for "file does not exist".
+		// Instead just ignore error and blow up when we try to listen, which will
+		// indicate "address already in use" if file existed and we couldn't remove.
+		//nolint:errcheck,revive
+		os.Remove(addr)
+	}
+
+	switch protocol {
+	case "tcp", "tcp4", "tcp6", "unix", "unixpacket":
+		tlsCfg, err := sl.ServerConfig.TLSConfig()
+		if err != nil {
+			return err
+		}
+
+		var l net.Listener
+		if tlsCfg == nil {
+			l, err = net.Listen(protocol, addr)
+		} else {
+			l, err = tls.Listen(protocol, addr, tlsCfg)
+		}
+		if err != nil {
+			return err
+		}
+
+		sl.Log.Infof("Listening on %s://%s", protocol, l.Addr())
+
+		// Set permissions on socket
+		if (spl[0] == "unix" || spl[0] == "unixpacket") && sl.SocketMode != "" {
+			// Convert from octal in string to int
+			i, err := strconv.ParseUint(sl.SocketMode, 8, 32)
+			if err != nil {
+				return err
+			}
+
+			if err := os.Chmod(spl[1], os.FileMode(uint32(i))); err != nil {
+				return err
+			}
+		}
+
+		ssl := &streamSocketListener{
+			Listener:       l,
+			SocketListener: sl,
+			sockType:       spl[0],
+		}
+
+		sl.Closer = ssl
+		sl.wg = sync.WaitGroup{}
+		sl.wg.Add(1)
+		go func() {
+			defer sl.wg.Done()
+			ssl.listen()
+		}()
+	case "udp", "udp4", "udp6", "ip", "ip4", "ip6", "unixgram":
+		decoder, err := internal.NewContentDecoder(sl.ContentEncoding)
+		if err != nil {
+			return err
+		}
+
+		pc, err := udpListen(protocol, addr)
+		if err != nil {
+			return err
+		}
+
+		// Set permissions on socket
+		if spl[0] == "unixgram" && sl.SocketMode != "" {
+			// Convert from octal in string to int
+			i, err := strconv.ParseUint(sl.SocketMode, 8, 32)
+			if err != nil {
+				return err
+			}
+
+			if err := os.Chmod(spl[1], os.FileMode(uint32(i))); err != nil {
+				return err
+			}
+		}
+
+		if sl.ReadBufferSize > 0 {
+			if srb, ok := pc.(setReadBufferer); ok {
+				if err := srb.SetReadBuffer(int(sl.ReadBufferSize)); err != nil {
+					sl.Log.Warnf("Setting read buffer on a %s socket failed: %v", protocol, err)
+				}
+			} else {
+				sl.Log.Warnf("Unable to set read buffer on a %s socket", protocol)
+			}
+		}
+
+		sl.Log.Infof("Listening on %s://%s", protocol, pc.LocalAddr())
+
+		psl := &packetSocketListener{
+			PacketConn:     pc,
+			SocketListener: sl,
+			decoder:        decoder,
+		}
+
+		sl.Closer = psl
+		sl.wg = sync.WaitGroup{}
+		sl.wg.Add(1)
+		go func() {
+			defer sl.wg.Done()
+			psl.listen()
+		}()
+	default:
+		return fmt.Errorf("unknown protocol '%s' in '%s'", protocol, sl.ServiceAddress)
+	}
+
+	if protocol == "unix" || protocol == "unixpacket" || protocol == "unixgram" {
+		sl.Closer = unixCloser{path: spl[1], closer: sl.Closer}
+	}
+
+	return nil
+}
+
+func udpListen(network string, address string) (net.PacketConn, error) {
+	switch network {
+	case "udp", "udp4", "udp6":
+		var addr *net.UDPAddr
+		var err error
+		var ifi *net.Interface
+		if spl := strings.SplitN(address, "%", 2); len(spl) == 2 {
+			address = spl[0]
+			ifi, err = net.InterfaceByName(spl[1])
+			if err != nil {
+				return nil, err
+			}
+		}
+		addr, err = net.ResolveUDPAddr(network, address)
+		if err != nil {
+			return nil, err
+		}
+		if addr.IP.IsMulticast() {
+			return net.ListenMulticastUDP(network, ifi, addr)
+		}
+		return net.ListenUDP(network, addr)
+	}
+	return net.ListenPacket(network, address)
+}
+
+func (sl *SocketListener) Stop() {
+	if sl.Closer != nil {
+		// Ignore the returned error as we cannot do anything about it anyway
+		//nolint:errcheck,revive
+		sl.Close()
+		sl.Closer = nil
+	}
+	sl.wg.Wait()
+}
+
+func newSocketListener() *SocketListener {
+	parser, _ := parsers.NewInfluxParser()
+
+	return &SocketListener{
+		Parser: parser,
+	}
+}
+
+type unixCloser struct {
+	path   string
+	closer io.Closer
+}
+
+func (uc unixCloser) Close() error {
+	err := uc.closer.Close()
+	// Ignore the error if e.g. the file does not exist
+	//nolint:errcheck,revive
+	os.Remove(uc.path)
+	return err
+}
+
+func init() {
+	inputs.Add("socket_listener", func() telegraf.Input { return newSocketListener() })
+}

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -1,0 +1,280 @@
+package socket_listener
+
+import (
+	"bytes"
+	"crypto/tls"
+	"io"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/influxdata/wlog"
+)
+
+var pki = testutil.NewPKI("../../../testutil/pki")
+
+// prepareLog is a helper function to ensure no data is written to log.
+// Should be called at the start of the test, and returns a function which should run at the end.
+func prepareLog(t *testing.T) func() {
+	buf := bytes.NewBuffer(nil)
+	log.SetOutput(wlog.NewWriter(buf))
+
+	level := wlog.WARN
+	wlog.SetLevel(level)
+
+	return func() {
+		log.SetOutput(os.Stderr)
+
+		for {
+			line, err := buf.ReadBytes('\n')
+			if err != nil {
+				require.Equal(t, io.EOF, err)
+				break
+			}
+			require.Empty(t, string(line), "log not empty")
+		}
+	}
+}
+
+func TestSocketListener_tcp_tls(t *testing.T) {
+	testEmptyLog := prepareLog(t)
+	defer testEmptyLog()
+
+	sl := newSocketListener()
+	sl.Log = testutil.Logger{}
+	sl.ServiceAddress = "tcp://127.0.0.1:0"
+	sl.ServerConfig = *pki.TLSServerConfig()
+
+	acc := &testutil.Accumulator{}
+	err := sl.Start(acc)
+	require.NoError(t, err)
+	defer sl.Stop()
+
+	tlsCfg, err := pki.TLSClientConfig().TLSConfig()
+	require.NoError(t, err)
+
+	secureClient, err := tls.Dial("tcp", sl.Closer.(net.Listener).Addr().String(), tlsCfg)
+	require.NoError(t, err)
+
+	testSocketListener(t, sl, secureClient)
+}
+
+func TestSocketListener_unix_tls(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "telegraf")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unix_tls.sock")
+
+	sl := newSocketListener()
+	sl.Log = testutil.Logger{}
+	sl.ServiceAddress = "unix://" + sock
+	sl.ServerConfig = *pki.TLSServerConfig()
+
+	acc := &testutil.Accumulator{}
+	err = sl.Start(acc)
+	require.NoError(t, err)
+	defer sl.Stop()
+
+	tlsCfg, err := pki.TLSClientConfig().TLSConfig()
+	require.NoError(t, err)
+	tlsCfg.InsecureSkipVerify = true
+
+	secureClient, err := tls.Dial("unix", sock, tlsCfg)
+	require.NoError(t, err)
+
+	testSocketListener(t, sl, secureClient)
+}
+
+func TestSocketListener_tcp(t *testing.T) {
+	testEmptyLog := prepareLog(t)
+	defer testEmptyLog()
+
+	sl := newSocketListener()
+	sl.Log = testutil.Logger{}
+	sl.ServiceAddress = "tcp://127.0.0.1:0"
+	sl.ReadBufferSize = config.Size(1024)
+
+	acc := &testutil.Accumulator{}
+	err := sl.Start(acc)
+	require.NoError(t, err)
+	defer sl.Stop()
+
+	client, err := net.Dial("tcp", sl.Closer.(net.Listener).Addr().String())
+	require.NoError(t, err)
+
+	testSocketListener(t, sl, client)
+}
+
+func TestSocketListener_udp(t *testing.T) {
+	testEmptyLog := prepareLog(t)
+	defer testEmptyLog()
+
+	sl := newSocketListener()
+	sl.Log = testutil.Logger{}
+	sl.ServiceAddress = "udp://127.0.0.1:0"
+	sl.ReadBufferSize = config.Size(1024)
+
+	acc := &testutil.Accumulator{}
+	err := sl.Start(acc)
+	require.NoError(t, err)
+	defer sl.Stop()
+
+	client, err := net.Dial("udp", sl.Closer.(net.PacketConn).LocalAddr().String())
+	require.NoError(t, err)
+
+	testSocketListener(t, sl, client)
+}
+
+func TestSocketListener_unix(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "telegraf")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unix.sock")
+
+	testEmptyLog := prepareLog(t)
+	defer testEmptyLog()
+
+	f, _ := os.Create(sock)
+	require.NoError(t, f.Close())
+	sl := newSocketListener()
+	sl.Log = testutil.Logger{}
+	sl.ServiceAddress = "unix://" + sock
+	sl.ReadBufferSize = config.Size(1024)
+
+	acc := &testutil.Accumulator{}
+	err = sl.Start(acc)
+	require.NoError(t, err)
+	defer sl.Stop()
+
+	client, err := net.Dial("unix", sock)
+	require.NoError(t, err)
+
+	testSocketListener(t, sl, client)
+}
+
+func TestSocketListener_unixgram(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
+	}
+
+	tmpdir, err := os.MkdirTemp("", "telegraf")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unixgram.sock")
+
+	testEmptyLog := prepareLog(t)
+	defer testEmptyLog()
+
+	_, err = os.Create(sock)
+	require.NoError(t, err)
+	sl := newSocketListener()
+	sl.Log = testutil.Logger{}
+	sl.ServiceAddress = "unixgram://" + sock
+	sl.ReadBufferSize = config.Size(1024)
+
+	acc := &testutil.Accumulator{}
+	err = sl.Start(acc)
+	require.NoError(t, err)
+	defer sl.Stop()
+
+	client, err := net.Dial("unixgram", sock)
+	require.NoError(t, err)
+
+	testSocketListener(t, sl, client)
+}
+
+func TestSocketListenerDecode_tcp(t *testing.T) {
+	testEmptyLog := prepareLog(t)
+	defer testEmptyLog()
+
+	sl := newSocketListener()
+	sl.Log = testutil.Logger{}
+	sl.ServiceAddress = "tcp://127.0.0.1:0"
+	sl.ReadBufferSize = config.Size(1024)
+	sl.ContentEncoding = "gzip"
+
+	acc := &testutil.Accumulator{}
+	err := sl.Start(acc)
+	require.NoError(t, err)
+	defer sl.Stop()
+
+	client, err := net.Dial("tcp", sl.Closer.(net.Listener).Addr().String())
+	require.NoError(t, err)
+
+	testSocketListener(t, sl, client)
+}
+
+func TestSocketListenerDecode_udp(t *testing.T) {
+	testEmptyLog := prepareLog(t)
+	defer testEmptyLog()
+
+	sl := newSocketListener()
+	sl.Log = testutil.Logger{}
+	sl.ServiceAddress = "udp://127.0.0.1:0"
+	sl.ReadBufferSize = config.Size(1024)
+	sl.ContentEncoding = "gzip"
+
+	acc := &testutil.Accumulator{}
+	err := sl.Start(acc)
+	require.NoError(t, err)
+	defer sl.Stop()
+
+	client, err := net.Dial("udp", sl.Closer.(net.PacketConn).LocalAddr().String())
+	require.NoError(t, err)
+
+	testSocketListener(t, sl, client)
+}
+
+func testSocketListener(t *testing.T, sl *SocketListener, client net.Conn) {
+	mstr12 := []byte("test,foo=bar v=1i 123456789\ntest,foo=baz v=2i 123456790\n")
+	mstr3 := []byte("test,foo=zab v=3i 123456791\n")
+
+	if sl.ContentEncoding == "gzip" {
+		encoder, err := internal.NewContentEncoder(sl.ContentEncoding)
+		require.NoError(t, err)
+		mstr12, err = encoder.Encode(mstr12)
+		require.NoError(t, err)
+
+		encoder, err = internal.NewContentEncoder(sl.ContentEncoding)
+		require.NoError(t, err)
+		mstr3, err = encoder.Encode(mstr3)
+		require.NoError(t, err)
+	}
+
+	_, err := client.Write(mstr12)
+	require.NoError(t, err)
+	_, err = client.Write(mstr3)
+	require.NoError(t, err)
+	acc := sl.Accumulator.(*testutil.Accumulator)
+
+	acc.Wait(3)
+	acc.Lock()
+	m1 := acc.Metrics[0]
+	m2 := acc.Metrics[1]
+	m3 := acc.Metrics[2]
+	acc.Unlock()
+
+	require.Equal(t, "test", m1.Measurement)
+	require.Equal(t, map[string]string{"foo": "bar"}, m1.Tags)
+	require.Equal(t, map[string]interface{}{"v": int64(1)}, m1.Fields)
+	require.True(t, time.Unix(0, 123456789).Equal(m1.Time))
+
+	require.Equal(t, "test", m2.Measurement)
+	require.Equal(t, map[string]string{"foo": "baz"}, m2.Tags)
+	require.Equal(t, map[string]interface{}{"v": int64(2)}, m2.Fields)
+	require.True(t, time.Unix(0, 123456790).Equal(m2.Time))
+
+	require.Equal(t, "test", m3.Measurement)
+	require.Equal(t, map[string]string{"foo": "zab"}, m3.Tags)
+	require.Equal(t, map[string]interface{}{"v": int64(3)}, m3.Fields)
+	require.True(t, time.Unix(0, 123456791).Equal(m3.Time))
+}


### PR DESCRIPTION
We use this plugin internally, and there isn't a OT receiver for carbon2 metrics yet.